### PR TITLE
Update MSPPaymentCreatorOrderUbercart.inc

### DIFF
--- a/modules/msp_payment_uc/includes/MSPPaymentCreatorOrderUbercart.inc
+++ b/modules/msp_payment_uc/includes/MSPPaymentCreatorOrderUbercart.inc
@@ -75,9 +75,7 @@ class MSPPaymentCreatorOrderUbercart extends MultiSafePayPaymentCreatorOrderBase
     $amount = $wrapper_uc_order->order_total->value();
 
     // Amount must be in cents es.10,00euro => 1000
-    // TODO: correct conversion because created problem to cast.
-    $amount = (float) $amount;
-    $amount = $amount * 100;
+    $amount = round($amount * 100, 0);
 
     // Return array order.
     $msp_order = array(


### PR DESCRIPTION
Spulciando nella documentazione della versione precedente del modulo (quello messo a disposizione su https://wwwv1.multisafepay.com/it/Plugins-Negozio/ubercart.html ) utilizzano la funzione: $amount = round($amount \* 100, 0);
Dovrebbe bastare.
